### PR TITLE
Add support for stroked/outlined text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- New `strokeColor` and `strokeWidth` text formatting options to control the outline of the text ([#292](https://github.com/stefcameron/text-to-canvas/issues/292)).
+    - Note that due to how the `strokeText()` and `measureText()` Canvas APIs work, the stroke is __not considered__ in text placement. Setting a large width will result in the stroke "bleeding" outside the text box.
+
 ## v1.1.2
 
 - Fixed bug where `drawText()` config `fontColor` option was not being included in the base font format used to render the text ([#64](https://github.com/stefcameron/text-to-canvas/issues/64)).

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ You can run this demo locally with `npm run node:demo`
 | `fontVariant`     | `''`         | Base font variant, same as css font-variant. Examples: `small-caps`. |
 | `fontWeight`      | `'400'`      | Base font weight, same as css font-weight. Examples: `bold`, `100`. |
 | `fontColor`       | `'black'`    | Base font color, same as css color. Examples: `blue`, `#00ff00`. |
+| `strokeColor`     | `'black'`    | Base stroke color, same as css color. Examples: `blue`, `#00ff00`. |
+| `strokeWidth`     | `0`          | Base stroke width. Positive number; `<=0` means none. Can be fractional. ⚠️ Word splitting does not take into account the stroke, which is applied on the __center__ of the edges of the text via the [strokeText()](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeText) Canvas API. Setting a thick stroke will cause it to bleed out of the text box. |
 | `justify`         | `false`      | Justify text if `true`, it will insert spaces between words when necessary. |
 | `inferWhitespace` | `true`       | If whitespace in the text should be inferred. Only applies if the text given to `drawText()` is a `Word[]`. If the text is a `string`, this config setting is ignored. |
 | `overflow`        | `true`       | Allows the text to overflow out of the box if the box is too narrow/short to fit it all. `false` will clip the text to the box's boundaries. |
@@ -305,6 +307,10 @@ const drawWords = (baseFormat: TextFormat, spec: RenderSpec) => {
   ctx.textBaseline = textBaseline;
   ctx.font = getTextStyle(baseFormat);
   ctx.fillStyle = baseFormat.fontColor;
+  ctx.strokeStyle = baseFormat.strokeColor;
+  ctx.lineJoin = 'round';
+
+  const baseStrokeWidth = baseFormat.strokeWidth
 
   lines.forEach((line) => {
     line.forEach((pw) => {
@@ -315,8 +321,19 @@ const drawWords = (baseFormat: TextFormat, spec: RenderSpec) => {
           if (pw.format.fontColor) {
             ctx.fillStyle = pw.format.fontColor;
           }
+          if (pw.format.strokeColor) {
+            ctx.strokeStyle = pw.format.strokeColor;
+          }
         }
         ctx.fillText(pw.word.text, pw.x, pw.y);
+        // stroke AFTER fill so it goes on top
+        const lineWidth = typeof pw.format?.strokeWidth === 'number'
+          ? pw.format.strokeWidth
+          : baseStrokeWidth;
+        if (lineWidth > 0) {
+          ctx.lineWidth = lineWidth;
+          ctx.strokeText(pw.word.text, pw.x, pw.y);
+        }
         if (pw.format) {
           ctx.restore();
         }

--- a/src/demos/node-demo.mts
+++ b/src/demos/node-demo.mts
@@ -27,7 +27,12 @@ async function main() {
     if (word.text === 'ipsum') {
       word.format = { fontStyle: 'italic', fontColor: 'red' };
     } else if (word.text === 'consectetur') {
-      word.format = { fontWeight: '700', fontColor: 'blue' };
+      word.format = {
+        fontWeight: '700',
+        fontColor: 'blue',
+        strokeColor: 'cyan',
+        strokeWidth: 0.5,
+      };
     }
   });
 
@@ -47,6 +52,8 @@ async function main() {
       fontFamily: 'Times New Roman, serif',
       fontWeight: '400',
       fontColor: 'green',
+      strokeColor: 'yellow',
+      strokeWidth: 0.25,
       debug: true,
     }));
   } catch (err) {

--- a/src/docs/AppCanvas.vue
+++ b/src/docs/AppCanvas.vue
@@ -15,6 +15,8 @@ const initialConfig = {
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin convallis eros.',
   pos: { x: 100, y: 150 },
   size: { w: 300, h: 200 },
+  fontSize: 24,
+  strokeWidth: 0,
   align: 'center',
   vAlign: 'middle',
   justify: false,
@@ -56,9 +58,11 @@ function renderText() {
     overflow: config.overflow,
     // currently not configurable in demo UI
     fontFamily: 'Times New Roman, serif',
-    fontSize: 24,
+    fontSize: config.fontSize,
     fontWeight: '400',
     fontColor: 'slategray',
+    strokeWidth: config.strokeWidth,
+    strokeColor: 'lime',
   };
 
   const words = textToWords(config.text);
@@ -66,7 +70,12 @@ function renderText() {
     if (word.text === 'ipsum') {
       word.format = { fontStyle: 'italic', fontColor: 'red' };
     } else if (word.text === 'consectetur') {
-      word.format = { fontWeight: 'bold', fontColor: 'blue' };
+      word.format = {
+        fontWeight: 'bold',
+        fontColor: 'blue',
+        strokeColor: 'cyan',
+        strokeWidth: 0.5,
+      };
     }
   });
 
@@ -116,16 +125,43 @@ onMounted(() => {
           placeholder="Please input"
         />
         <p>
-          The library uses the concept of textboxes borrowed from popular image
-          editing software. You draw a rectangular box then place the text in
-          the box. Turn on <strong>debug mode</strong> (below) to see what is
-          happening.
+          💬 To keep the demo app simple while showing the library's rich text
+          features, the word "ipsum" is always rendered in italics/red without a
+          stroke, and the word "consectetur" always in bold/blue with a cyan
+          stroke fixed at 0.5px.
         </p>
         <p>
-          💬 To keep the demo app simple while showing the library's rich text
-          features, the word "ipsum" is always rendered in italics/red and the
-          word "consectetur" always in bold/blue.
+          🔺 Setting the <code>Stroke</code> too large will cause it to bleed
+          out of the box. <strong>This is expected</strong>, and a limitation of
+          using the <code>strokeText()</code> Canvas API to stroke the text. The
+          stroke is always drawn on the center of the edges, and is not
+          considered by the <code>measureText()</code> Canvas API.
         </p>
+        <p>
+          Turn on <strong>debug mode</strong> (below) to see the text box
+          boundaries.
+        </p>
+        <div class="slider">
+          <span class="label">Font size</span>
+          <el-slider
+            v-model="config.fontSize"
+            show-input
+            :min="0"
+            :max="128"
+            size="small"
+          />
+        </div>
+        <div class="slider">
+          <span class="label">Stroke 🔺</span>
+          <el-slider
+            v-model="config.strokeWidth"
+            show-input
+            :min="0"
+            :max="20"
+            :step="0.5"
+            size="small"
+          />
+        </div>
         <div class="slider">
           <span class="label">Pos X</span>
           <el-slider

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -29,6 +29,8 @@ export interface TextFormat {
   /**
    * Font size (px).
    *
+   * Base text format defaults to 14px. Otherwise, defaults to base text format.
+   *
    * ❗️ Rendering words at different sizes currently does not render well per text baseline.
    *  Prefer setting a common size as the base formatting for all text instead of setting
    *  a different size for a subset of Words.
@@ -45,8 +47,27 @@ export interface TextFormat {
   /** Font variant (CSS value). */
   fontVariant?: 'normal' | 'small-caps' | '';
 
-  /** CSS color value. */
+  /**
+   * CSS color value.
+   *
+   * Base text format defaults to black. Otherwise, defaults to base text format.
+   */
   fontColor?: string;
+
+  /**
+   * CSS color value.
+   *
+   * Base text format defaults to black. Otherwise, defaults to base text format.
+   */
+  strokeColor?: string;
+
+  /**
+   * Stroke width in pixels. `>= 0`, can be fractional.
+   *
+   * Base text format defaults to 0, which means no stroke/outline. Otherwise, defaults to
+   *  base text format.
+   */
+  strokeWidth?: number;
 
   // NOTE: line height is not currently supported
 }

--- a/src/lib/util/height.ts
+++ b/src/lib/util/height.ts
@@ -10,6 +10,9 @@ const _getHeight = (ctx: CanvasRenderContext, text: string, style?: string) => {
   if (style) {
     ctx.font = style;
   }
+
+  // NOTE: this API does NOT account for the `lineWidth` used to add the stroke
+  //  effect via `strokeText()`; the stroke will bleed out of the measured box
   const { actualBoundingBoxAscent: height } = ctx.measureText(text);
 
   // Reset baseline

--- a/src/lib/util/split.ts
+++ b/src/lib/util/split.ts
@@ -353,7 +353,10 @@ const _measureWord = ({
     ctx.textBaseline = 'bottom';
   }
 
+  // NOTE: this API does NOT account for the `lineWidth` used to add the stroke
+  //  effect via `strokeText()`; the stroke will bleed out of the measured box
   const metrics = ctx.measureText(word.text);
+
   if (typeof metrics.fontBoundingBoxAscent === 'number') {
     fontBoundingBoxSupported = true;
   } else {

--- a/src/lib/util/style.ts
+++ b/src/lib/util/style.ts
@@ -3,6 +3,9 @@ import { TextFormat } from '../model';
 export const DEFAULT_FONT_FAMILY = 'Arial';
 export const DEFAULT_FONT_SIZE = 14;
 export const DEFAULT_FONT_COLOR = 'black';
+export const DEFAULT_STROKE_COLOR = DEFAULT_FONT_COLOR;
+export const DEFAULT_STROKE_WIDTH = 0;
+export const DEFAULT_STROKE_JOIN = 'round';
 
 /**
  * Generates a text format based on defaults and any provided overrides.
@@ -23,6 +26,8 @@ export const getTextFormat = (
       fontStyle: '',
       fontVariant: '',
       fontColor: DEFAULT_FONT_COLOR,
+      strokeColor: DEFAULT_STROKE_COLOR,
+      strokeWidth: DEFAULT_STROKE_WIDTH,
     },
     baseFormat,
     format


### PR DESCRIPTION
Fixes #292

## Examples

The demo has been updated to add an optional lime-green stroke (using a new slider) to the entire text, except for the word "consectetur" which always has a cyan stroke:

<img width="543" alt="Screenshot 2025-01-14 at 4 33 08 PM" src="https://github.com/user-attachments/assets/3c5863b3-4703-4950-9d73-fc85b6d62b43" />

Here's a sample using `'#00000000'` (transparent black) as the `fontColor` and `'black'` as the `strokeColor` with `strokeWidth=1`:

<img width="544" alt="Screenshot 2025-01-14 at 4 47 45 PM" src="https://github.com/user-attachments/assets/b8ab8109-9135-4b7e-81a9-e277789dac5e" />


<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain browser compatibility.
- Web APIs introduced have __broad__ browser coverage (remember to check Safari which is often very late to adopt new APIs).
- Docs app has been updated (if applicable).
- Unit test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changelog entry added under "UNRELEASED" section (added if did not exist).
  - See [Contributing](../CONTRIBUTING.md) instructions for guidance.
  - EXCEPTION: A Changelog entry is not required if the change does not affect any of the source files that produce the package bundles. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changelog entry since it will not affect package consumers.

</details>
